### PR TITLE
Fix in staging

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -33,7 +33,8 @@ var webpackConfig = merge(baseWebpackConfig, {
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
-        warnings: false
+        warnings: false,
+        comparisons: false
       },
       sourceMap: true
     }),

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -18,7 +18,8 @@ var webpackConfig = merge(baseWebpackConfig, {
     rules: utils.styleLoaders({
       sourceMap: config.build.productionSourceMap,
       extract: true
-    })
+    }),
+    noParse: /(mapbox-gl)\.js$/
   },
   devtool: config.build.productionSourceMap ? '#source-map' : false,
   output: {
@@ -33,8 +34,7 @@ var webpackConfig = merge(baseWebpackConfig, {
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
-        warnings: false,
-        comparisons: false
+        warnings: false
       },
       sourceMap: true
     }),

--- a/index.html
+++ b/index.html
@@ -41,6 +41,9 @@
     </script>
     <noscript><p><img src="//stats.data.gouv.fr/piwik.php?idsite=44" style="border:0;" alt="" /></p></noscript>
     <!-- End Piwik Code -->
+
+    <!-- Mapbox-gl CSS -->
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.2/mapbox-gl.css' rel='stylesheet' />
   </head>
   <body>
 

--- a/src/components/etablissement/EtablissementMap.vue
+++ b/src/components/etablissement/EtablissementMap.vue
@@ -41,8 +41,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import '/node_modules/mapbox-gl/dist/mapbox-gl.css';
-
   #map {
     padding: 0;
     height: 400px;


### PR DESCRIPTION
1/ Mapboxgl CSS isn't imported correctly in bundler mode, instead I added a link to the CDN in index.html as recommended in official docs.

2/ Parsing during production build made mapboxgl fail in production. Solutions are to configure webpack to disable comparisons on the uglify module, or add a noParse option for mapbox. I choosed the latest solution since it is less intrusive.

mapbox now work correctly in production.